### PR TITLE
Oprava rozbalovacích boxíků

### DIFF
--- a/assets/_scss/core_design.scss
+++ b/assets/_scss/core_design.scss
@@ -309,6 +309,10 @@ details {
             display: inline;
             margin-left: 0.5em;
         }
+
+        h2::before, h3::before, h4::before {
+            content: none;
+        }
     }
 
     > summary:hover {


### PR DESCRIPTION
Tento PR opravuje rozbalovací boxíky (obecně, k vidění jsou momentálně na stránce atlasu). Ty byly rozbity úpravou doprovodných textů grafik.

Fixes #741 