### PR TITLE
správny link na Ceniu

### DIFF
--- a/_data/resources.yml
+++ b/_data/resources.yml
@@ -13,7 +13,7 @@ web_cs:
 
   - title: "CENIA"
     tags: [ zdroje, česky, Česká republika ]
-    url: "http://chmi.cz/"
+    url: "https://www.cenia.cz/#aktuality_"
     image: "cenia.png"
     description-short: "CENIA, česká informační agentura životního prostředí, příspěvková organizace MŽP."
     description-long: " Posláním CENIA je shromažďování, hodnocení a interpretace informací o životním prostředí a jejich poskytování odborné i laické veřejnosti. Web obsahuje např. každoročně updatované publikace [Statistická ročenka životního prostředí ČR](https://www.cenia.cz/publikace/statisticka-rocenka-zivotniho-prostredi-cr/) a [Zpráva o životním prostředí ČR](https://www.cenia.cz/publikace/zpravy-o-zp/), nebo datový portál [ISSaR](https://issar.cenia.cz/), kde je možné vyhledávat údaje o emisích a kvalitě ovzduší, spotřebě energie, jakosti vody a dalších indikátorech životního prostředí."


### PR DESCRIPTION
v Resources bola Cenia prelinkovaná na chmi.cz -> náhrada za link na cenia.cz