### PR TITLE
Přidání redirectu na infografiku srovnání scénářů

### DIFF
--- a/_infographics/energetika/srovnani-energetickych-scenaru-cr.md
+++ b/_infographics/energetika/srovnani-energetickych-scenaru-cr.md
@@ -2,6 +2,7 @@
 layout:      infographic
 title:       "Srovnání scénářů transformace elektroenergetiky ČR"
 slug:        "srovnani-energetickych-scenaru-cr"
+redirect_from: "/srovnani-scenaru"
 published:   2020-11-20
 weight:      73
 tags-scopes: [ cr ]


### PR DESCRIPTION
Přidán redirect z `/srovnani-scenaru` tak, aby fungoval odkaz v grafice.

Fixes #806