### PR TITLE
Zapnutí podpory pro matematické vzorce

### DIFF
--- a/_config.local.yml
+++ b/_config.local.yml
@@ -62,4 +62,5 @@ jekyll-archives:
 
 # Enable Czech smart quotes
 kramdown:
-    smart_quotes: sbquo,lsquo,bdquo,ldquo
+  math_engine: katex
+  smart_quotes: sbquo,lsquo,bdquo,ldquo


### PR DESCRIPTION
Závisí na faktaoklimatu/web-core#54.

Příklad použití:

    Pythagorova věta $$\oint_\mathcal{C} f(x^2) dx = \frac{a^2 + b^2}{c^2}$$ aproximuje, o kolik se oteplí.

    Následující vzorec se zobrazí v _display modu_:

    $$\oint_\mathcal{C} f(x^2) dx = \frac{a^2 + b^2}{c^2}$$

Výsledek:

![Screenshot_2021-04-10 Jak ovlivňuje dýchání člověka, živočichů a rostlin koncentrace CO sub 2 sub v atmosféře (1)](https://user-images.githubusercontent.com/134321/114279720-5f236a00-9a36-11eb-9158-a5e475b438f0.png)
