### PR TITLE
Fix crash in glyph replacement plugin

### DIFF
--- a/plugins-local/glyph-replacement-czech.rb
+++ b/plugins-local/glyph-replacement-czech.rb
@@ -2,7 +2,7 @@
 
 Jekyll::Hooks.register :site, :post_render do |site|
   Jekyll.logger.info  "                  * Replacing non-breaking spaces (Czech) ..."
-  
+
   def replace!(content)
     # One-letter conjunctions and prepositions should not be left hanging.
     content.gsub!(/([ \()])([aikosuvz]) /i, '\1\2&nbsp;')
@@ -14,7 +14,10 @@ Jekyll::Hooks.register :site, :post_render do |site|
   end
 
   site.documents.each do |page|
-    Jekyll.logger.error "Undefined page.output for '#{page.path}'. Consider excluding this file" if not page.respond_to? :output
+    if not page.respond_to? :output
+      Jekyll.logger.error "Undefined page.output for '#{page.path}'. Consider excluding this file"
+      continue
+    end
     replace!(page.output)
   end
 


### PR DESCRIPTION
In case the `page` object has no `output` property, an error gets logged but execution continues as though nothing has happened. We need to skip processing the document in case an error like this occurs.

Follow-up to faktaoklimatu/web-core#61.