### PR TITLE
Newsletter předělán na Ecomail

### DIFF
--- a/_config.local.yml
+++ b/_config.local.yml
@@ -9,7 +9,7 @@ github: faktaoklimatu/web-cz
 twitter: "faktaoklimatu"
 facebook: "faktaoklimatu"
 linkedin: "68480136"
-newsletter: "https://tinyletter.com/faktaoklimatu/subscribe"
+newsletter: "7-c01458c4e85a58f0047857fac06ae283"
 fundraising: "https://www.darujme.cz/projekt/1203742"
 author: faktaoklimatu.cz
 copyright: "&copy; 2021 Otevřená data o klimatu, z. ú."

--- a/_pages/aktuality.html
+++ b/_pages/aktuality.html
@@ -13,17 +13,7 @@ search_type: "Aktuality"
         <p class="lead">{{ page.intro }}</p>
         <p class="lead">Chcete dostávat pravidelné aktualizace přes email? Přihlaste se k odběru našeho newsletteru: Krátký sumář novinek na našem webu maximálně jednou za měsíc (a spíše méně často).</p>
 
-        <form class="subscription-form" action="{{ site.newsletter }}" target="_blank" method="post">
-            <div class="input-group">
-                <div class="input-group-prepend">
-                    <span class="input-group-text">Vaše emailová adresa:</span>
-                </div>
-                <input type="text" class="form-control" placeholder="email@email.cz" name="email" id="tlemail" aria-label="Emailová adresa" />
-                <div class="input-group-append">
-                    <input type="submit" class="btn btn-primary" value="Přihlásit se k odběru novinek" />
-                </div>
-            </div>
-        </form>
+        <a href="#newsletter-modal" class="btn btn-primary" id="newsletter-embed" data-toggle="modal" data-target="#newsletter-modal"><i class="fas fa-fw fa-envelope-open-text"></i> Přihlásit se k newsletteru</a>
          
     </div>
 </div>

--- a/_pages/dekujeme.md
+++ b/_pages/dekujeme.md
@@ -31,7 +31,7 @@ sitemap:    false
         <p class="lead">I díky vašemu příspěvku můžeme dál fungovat. V případě dotazů se nám neváhejte ozvat na <a href="mailto:dary@faktaoklimatu.cz" title="Kontaktní adresa pro dárce">dary@faktaoklimatu.cz</a>.</p>
         <hr/>
         <p class="pb-2">Chcete-li být informováni o novinkách, přihlaste se do odběru našeho newslettru nebo sledujte náš Twitter.</p>
-        <a href="{{ site.newsletter }}" target="_blank" class="btn btn-primary"><i class="fas fa-fw fa-envelope-open-text"></i> Newsletter</a>
+        <a href="#newsletter-modal" class="btn btn-primary" id="newsletter-embed" data-toggle="modal" data-target="#newsletter-modal"><i class="fas fa-fw fa-envelope-open-text"></i> Newsletter</a>
         <a href="https://twitter.com/{{ site.twitter }}" target="_blank" class="btn btn-secondary"><i class="fab fa-fw fa-twitter"></i> Twitter</a>
         <figure class="d-md-none w-100 mt-2">
             <img src="/assets-local/team/fakta-tym.jpg" class="rounded w-100" alt="Jádro týmu Fakta o klimatu"/>

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -35,7 +35,7 @@ slug: index
     <p class="lead">Pro pravidelné kvalitní informace o klimatické změně můžete sledovat náš newsletter nebo Twitter.
     Komplexní a přístupný pohled na klimatickou změnu představuje naše publikace <a href="/atlas" target="_blank">Atlas klimatické změny</a>.
     Kvalitní debatu o klimatické změně a projekt Fakta o klimatu můžete také podpořit – finančně nebo používáním našich dat a grafik.</p>
-    <a href="{{ site.newsletter }}" target="_blank" class="btn btn-primary"><i class="fas fa-fw fa-envelope-open-text"></i> Newsletter</a>
+    <a href="#newsletter-modal" class="btn btn-primary" id="newsletter-embed" data-toggle="modal" data-target="#newsletter-modal"><i class="fas fa-fw fa-envelope-open-text"></i> Newsletter</a>
     <a href="https://twitter.com/{{ site.twitter }}" target="_blank" class="btn btn-secondary"><i class="fab fa-fw fa-twitter"></i> Twitter</a>
     <a href="/temata/emise/" class="btn btn-secondary"><i class="fas fa-fw fa-binoculars"></i> Explainery</a>
     <a href="/slovnik" class="btn btn-secondary"><i class="fas fa-fw fa-book"></i> Slovník pojmů</a>

--- a/assets-local/local.scss
+++ b/assets-local/local.scss
@@ -3,5 +3,4 @@
 .intro {
     .tagline { width: 15.2rem; }
     p { padding-left: 19rem; }
-    form { padding-left: 19rem; }
 }


### PR DESCRIPTION
Aktualizován web-core. Interní náhled dostupný na https://cz-fakta-o-klimatu--preview-newsletter-ecomail-nncd42bv.web.app/

* [x] @anna-macek, mozes to prosim prejst a skontrolovat, ze vsetko funguje, ak ma?
* [x] @anna-macek, patri sa, aby ma newsletter tzv. _double opt-in_, tj. aby ti po prihlaseni na stranke este prisiel potvrdzovaci email, kde to musis odkliknut. Nachystala by si mi prosim sablonu tohto emailu v Ecomaile? Mozes si pomoct formulaciou na cudzich newslettroch. V zasade, nech to ma rovnaky vizualny styl, ako newslettre, velke tlacitko, ktore vedie na `*|SUBCONFIRM|*` a pod tym mozno text, ze ak tlacitko nefunguje, mozu skopirovat odkaz `*|SUBCONFIRM|*` do prehliadaca (alebo to uz je v dnesnej dobe archaizmus?).