### PR TITLE
Vylepšení pluginu pro nahrazování mezer

### DIFF
--- a/plugins-local/glyph-replacement-czech.rb
+++ b/plugins-local/glyph-replacement-czech.rb
@@ -5,12 +5,12 @@ Jekyll::Hooks.register :site, :post_render do |site|
 
   def replace!(content)
     # One-letter conjunctions and prepositions should not be left hanging.
-    content.gsub!(/([ \()])([aikosuvz]) /i, '\1\2&nbsp;')
+    content.gsub!(/(?<=[\s(])([aikosuvz]) +/i, "\\1\u00a0")
     # Nonbreaking space after common abbreviations with and without period after space or opening parenthesis.
-    content.gsub!(/([ \()])(srov|tzn|tzv|tj|vs|např|popř|č|mj|zvl|r|str|angl)\. /i, '\1\2.&nbsp;')
-    content.gsub!(/([ \()])(viz|cca) /i, '\1\2&nbsp;')
-    # Nonbreaking space before common ending abbreviations before space or end parenthesis.
-    content.gsub!(/ (aj|atd|apod)\.([ \)])/i, '&nbsp;\1.\2')
+    content.gsub!(/(?<=[\s(])(srov|tzn|tzv|tj|vs|např|popř|č|mj|zvl|r|str|angl)\. +/i, "\\1.\u00a0")
+    content.gsub!(/(?<=[\s(])(viz|cca) +/i, "\\1\u00a0")
+    # Nonbreaking space before common ending abbreviations before space or closing parenthesis.
+    content.gsub!(/\s+(aj|atd|apod)\.(?=[\s)])/i, "\u00a0\\1.")
   end
 
   site.documents.each do |page|


### PR DESCRIPTION
* Použití unicodových glyfů namísto HTML entit.
* Použití look-ahead a look-behind místo explicitního záchytu. To mimochodem opravuje bug, kdy se v _„… letišť a v blízkosti vedení…“_ nahradila mezera za „a“, ale už ne za „v“.
* Použití `\s` místo jednoduché mezery.

Related: faktaoklimatu/web-core#94