### PR TITLE
Potlačení emoji zobrazení šipky

### DIFF
--- a/_config.local.yml
+++ b/_config.local.yml
@@ -72,3 +72,4 @@ jekyll-archives:
 kramdown:
   math_engine: katex
   smart_quotes: sbquo,lsquo,bdquo,ldquo
+  footnote_backlink: "↩︎"


### PR DESCRIPTION
Změna řetězce, kterým se v poznámkách pod čarou odkazuje zpět do textu, na verzi se [selektorem varianty](https://en.wikipedia.org/wiki/Variation_Selectors_(Unicode_block)) VS15 (U+FE0E). Tento selektor zajistí, že se šipky nezobrazí jako emoji, což je výchozí chování např. v Safari na iPhonu.

Ilustrace stavu před změnou a po:
![before-after](https://user-images.githubusercontent.com/134321/126362460-766313ea-2530-404a-bed9-f2fcb3bbd20e.png)
