### PR TITLE
Drobné opravy HTML na stránce O nás

### DIFF
--- a/_pages/o-nas.html
+++ b/_pages/o-nas.html
@@ -51,17 +51,17 @@ intro: "Debata o klimatické změně je komplikovaná a na všech stranách pln�
             <div class="col-12 col-sm-12 col-md-6 col-lg-4 col-lg-3">
                 <div class="card bg-transparent border-0">
                     <div class="text-center">
-                        <img class="card-img-top p-2" style="width: 50%; border-radius: 50%" src="/assets-local/team/{{item.img}}" alt="{{item.name }}">
+                        <img class="card-img-top p-2" style="width: 50%; border-radius: 50%" src="/assets-local/team/{{item.img}}" alt="{{item.name}}">
                     </div>
                     <div class="card-body d-flex flex-column">
                         <h5 class="card-title text-center">
-                            {{ item.name}} {% if item.linkedin%}<a class="no-ext-link-icon" href="{{ item.linkedin }}"><span class="fab fa-fw fa-linkedin"></span></a>{% endif %}
+                            {{ item.name }} {% if item.linkedin %}<a class="no-ext-link-icon" href="{{ item.linkedin }}"><span class="fab fa-fw fa-linkedin"></span></a>{% endif %}
                         </h5>
-                        <h6 class="card-subtitle mb-2 text-muted text-center">{{ item.position }}</h6>
-                        <p class="card-text text-center">{{ item.summary | markdownify }}</p>
+                        <h6 class="card-subtitle mb-3 text-muted text-center">{{ item.position }}</h6>
+                        <div class="card-text mb-3 text-center">{{ item.summary | markdownify }}</div>
                         {%- if item.email %}
                         <div class="mt-auto text-center">
-                            <a class="align-self-end" href="mailto:{{item.email }}">{{ item.email }}</a>
+                            <a class="align-self-end" href="mailto:{{ item.email }}">{{ item.email }}</a>
                         </div>
                         {% endif -%}
                     </div>


### PR DESCRIPTION
* Popisek u lidí obalen do `<div>`, protože filtr `markdownify` automaticky obaluje odstavce do `<p>`.
* Úpravy rozestupů v důsledku předchozího.
* Konzistentní mezery v Liquid šablonách.