### PR TITLE
Středníky za příkazy git (pro make 4.3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@ all build check local clean clean-build bundle-install container build-container
 	$(MAKE) -C $(WEB_CORE_FOLDER) $@
 
 web-core:
-	git submodule update --init --recursive
+	git submodule update --init --recursive;
 
 update-podcast: web-2050podcast
 
 web-2050podcast:
-	git submodule update --init --recursive
+	git submodule update --init --recursive;
 
 .PHONY: all build check local clean clean-build bundle-install container build-container delete-container lighthouse deploy-preview deploy-production
 .PHONY: web-core


### PR DESCRIPTION
make 4.3 potřebuje středník za příkazy git (viz https://stackoverflow.com/questions/62561355/permission-error-running-any-git-command-in-makefiles/62562135#comment124673218_62562135). Tento PR to opravuje.