### PR TITLE
Sjednocení emisních hodnot

### DIFF
--- a/collections/_topics/emise.md
+++ b/collections/_topics/emise.md
@@ -32,7 +32,7 @@ dashboard:
     value:     "**6,8**"
     subtitle:  "tun CO<sub>2</sub>eq"
   - region:    "cz"
-    value:     "**12,3**"     # vychádza to 12,25; počet obyvateľov World bank viď dataset Emise svět
+    value:     "**12,2**"  # Opět založeno na Eurostat datech, aby bylo konzistentní s dalšími grafikami.
     subtitle:  "tun CO<sub>2</sub>eq"
   source:      "Fakta o klimatu"
   source-url:  "/emise-svet-na-osobu"

--- a/collections/_topics/emise.md
+++ b/collections/_topics/emise.md
@@ -17,12 +17,12 @@ dashboard:
   title:       "**Celkové emise** za rok 2018"
   data:
   - region:    "world"
-    value:     "**51,2**"   # Tohle je tricky -> IPCC uvádí cca 58 Gt CO2eq. EDGAR nepočítá LULUCF a tvrdí, že LULUCF je souhrnně net sink (~ 5 Gt CO2). Oproti tomu IPCC uvádí LULUCF emise cca 6.6 Gt CO2, protože odlišně definuje "antropogenní" (nezahrnuje pohlcování existujícími ekosystémy).
+    value:     "**51,2**"  # Tohle je tricky -> IPCC uvádí cca 58 Gt CO2eq. EDGAR nepočítá LULUCF a tvrdí, že LULUCF je souhrnně net sink (~ 5 Gt CO2). Oproti tomu IPCC uvádí LULUCF emise cca 6.6 Gt CO2, protože odlišně definuje "antropogenní" (nezahrnuje pohlcování existujícími ekosystémy).
     subtitle:  "mld. tun CO<sub>2</sub>eq"
   - region:    "cz"
-    value:     "**131,4**"
+    value:     "**129**"  # Pro EU / Česko všude používáme Eurostat data (metriku TOTX4_MEMONIA). Sice to není zcela konzistentní s daty z Edgaru, ale je lepší používat všude stejné číslo.
     subtitle:  "mil. tun CO<sub>2</sub>eq"
-  source:      "EDGAR, European Commission"
+  source:      "EDGAR, European Commission (světové emise) a Eurostat (emise ČR)"
   source-url:  "https://edgar.jrc.ec.europa.eu/report_2021?vis=ghgtot#emissions_table"
 - type:        "compare"
   col-xl-size: "3-5"
@@ -69,7 +69,7 @@ subtopics:
   title:       "Množství emisí skleníkových plynů"
   title-short: "Množství emisí"
   lead: |
-    **V roce 2018 celý svět vypustil do atmosféry 48,9 miliard tun CO<sub>2</sub>eq**. Tato jednotka přepočítává množství různých skleníkových plynů na množství CO<sub>2</sub>, které by mělo stejný příspěvek ke skleníkovému jevu. Například metan je 28× silnější skleníkový plyn než oxid uhličitý (při uvažovaném stoletém horizontu), tedy 1 tuna metanu představuje 28 tun CO<sub>2</sub>eq.
+    **V roce 2018 celý svět vypustil do atmosféry 51,2 miliard tun CO<sub>2</sub>eq**. Tato jednotka přepočítává množství různých skleníkových plynů na množství CO<sub>2</sub>, které by mělo stejný příspěvek ke skleníkovému jevu. Například metan je 28× silnější skleníkový plyn než oxid uhličitý (při uvažovaném stoletém horizontu), tedy 1 tuna metanu představuje 28 tun CO<sub>2</sub>eq.
 
     Klimatická změna závisí na celkovém množství skleníkových plynů v atmosféře, při srovnávání jednotlivých zemí je však také vhodné vyjádření na obyvatele. Tím je možné porovnat, jak ke klimatické změně přispívají vzhledem k počtu obyvatel různě veliké státy.
   content:

--- a/collections/_topics/emise.md
+++ b/collections/_topics/emise.md
@@ -26,13 +26,13 @@ dashboard:
   source-url:  "https://edgar.jrc.ec.europa.eu/report_2021?vis=ghgtot#emissions_table"
 - type:        "compare"
   col-xl-size: "3-5"
-  title:       "**Emise na osobu** za rok 2015"
+  title:       "**Emise na osobu** za rok 2018"
   data:
   - region:    "world"
-    value:     "**6,5**"
+    value:     "**6,8**"
     subtitle:  "tun CO<sub>2</sub>eq"
   - region:    "cz"
-    value:     "**12,1**"
+    value:     "**12,3**"     # vychádza to 12,25; počet obyvateľov World bank viď dataset Emise svět
     subtitle:  "tun CO<sub>2</sub>eq"
   source:      "Fakta o klimatu"
   source-url:  "/emise-svet-na-osobu"


### PR DESCRIPTION
Navrhuju sjednotit údaje napříč stránkou témat (a napříč webem), že údaje světových emisí vycházejí z EDGARu a údaje pro jednotlivé evropské státy vždy vycházejí z dat eurostatu.

To vede k jisté metodické nedokonalosti, pokud se tyto hodnoty srovnávají mezi sebou, ale rozdíly jsou malé, tak bych to ignoroval. Jednotnost údajů napříč webem je důležitější.

Fixes #1133