### PR TITLE
Odstranění search_id parametru

### DIFF
--- a/collections/_pages/slovnik.html
+++ b/collections/_pages/slovnik.html
@@ -3,7 +3,6 @@ layout:      single-section-page
 title:       "Slovník pojmů"
 slug:        slovnik
 intro:       "Stručný přehled nejčastěji používaných hesel a zkratek s krátkým vysvětlením či komentářem."
-search_id:   glossary
 preview_type: "Slovník"
 include_in_search: true
 ---

--- a/collections/_pages/zdroje.html
+++ b/collections/_pages/zdroje.html
@@ -3,7 +3,6 @@ layout:      empty
 title:       "Další zdroje a odkazy"
 slug:        zdroje
 intro:       "Rozcestník odkazů na stránky vybraných výzkumných institucí, relevantních knih, repozitářů dat i projektů vizualizující data."
-search_id:   resources
 preview_type: "Zdroje"
 include_in_search: true
 ---


### PR DESCRIPTION
Tento PR uklízí už nepoužívaný parametr seach_id (odstraněný v
https://github.com/faktaoklimatu/web-core/pull/46).